### PR TITLE
Make notification dismissal set-based to avoid lag at scale

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <NoWarn>$(NoWarn);CS1591;CS0436</NoWarn>
     <AbpProjectType>module</AbpProjectType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/EasyAbp.ProcessManagement.Application/EasyAbp/ProcessManagement/Notifications/NotificationAppService.cs
+++ b/src/EasyAbp.ProcessManagement.Application/EasyAbp/ProcessManagement/Notifications/NotificationAppService.cs
@@ -142,38 +142,31 @@ public class NotificationAppService : ReadOnlyAppService<Notification, Notificat
         var now = Clock.Now;
         var userId = CurrentUser.GetId();
 
-        List<Notification> notifications = [];
+        // Fast path: dismiss every not-yet-dismissed notification of the current user up to the
+        // given time in a single set-based database update, without loading entities into memory.
+        // This keeps "dismiss all" responsive even when the user has a large number of notifications.
         if (input.MaxCreationTime.HasValue)
         {
-            notifications =
-                await Repository.GetListAsync(x => x.CreationTime <= input.MaxCreationTime && x.UserId == userId);
+            await _repository.DismissAllAsync(userId, input.MaxCreationTime.Value, now);
         }
 
-        if (input.NotificationIds != null)
+        // Dismiss an explicit (client-bounded) list of notifications by id.
+        if (input.NotificationIds is { Count: > 0 })
         {
-            foreach (var notificationId in input.NotificationIds.Where(notificationId =>
-                         notifications.All(x => x.Id != notificationId)))
+            var notificationIds = input.NotificationIds;
+            var notifications = await _repository.GetListAsync(x => notificationIds.Contains(x.Id));
+
+            if (notifications.Any(x => x.UserId != userId))
             {
-                var notification = await Repository.FindAsync(notificationId);
-                if (notification is null)
-                {
-                    continue;
-                }
-
-                if (notification.UserId != userId)
-                {
-                    await CheckPolicyAsync(ProcessManagementPermissions.Process.Manage);
-                }
-
-                notifications.Add(notification);
+                await CheckPolicyAsync(ProcessManagementPermissions.Process.Manage);
             }
-        }
 
-        foreach (var notification in notifications)
-        {
-            notification.SetDismissed(now);
+            foreach (var notification in notifications)
+            {
+                notification.SetDismissed(now);
+            }
 
-            await _repository.UpdateAsync(notification);
+            await _repository.UpdateManyAsync(notifications);
         }
 
         if (UnitOfWorkManager.Current != null)

--- a/src/EasyAbp.ProcessManagement.Domain/EasyAbp/ProcessManagement/Notifications/INotificationRepository.cs
+++ b/src/EasyAbp.ProcessManagement.Domain/EasyAbp/ProcessManagement/Notifications/INotificationRepository.cs
@@ -1,8 +1,30 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Volo.Abp.Domain.Repositories;
 
 namespace EasyAbp.ProcessManagement.Notifications;
 
 public interface INotificationRepository : IRepository<Notification, Guid>
 {
+    /// <summary>
+    /// Dismisses, in a single set-based database operation, all of the given user's
+    /// not-yet-dismissed notifications created at or before <paramref name="maxCreationTime"/>.
+    /// Entities are not loaded into memory, so it stays fast even with a large number of notifications.
+    /// </summary>
+    Task DismissAllAsync(
+        Guid userId,
+        DateTime maxCreationTime,
+        DateTime dismissedTime,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Dismisses, in a single set-based database operation, all not-yet-dismissed notifications
+    /// belonging to the given process. Entities are not loaded into memory, so it stays fast even
+    /// when the process has notifications for a large number of users.
+    /// </summary>
+    Task DismissByProcessIdAsync(
+        Guid processId,
+        DateTime dismissedTime,
+        CancellationToken cancellationToken = default);
 }

--- a/src/EasyAbp.ProcessManagement.Domain/EasyAbp/ProcessManagement/Notifications/ProcessChangedEventHandler.cs
+++ b/src/EasyAbp.ProcessManagement.Domain/EasyAbp/ProcessManagement/Notifications/ProcessChangedEventHandler.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using EasyAbp.ProcessManagement.Processes;
 using EasyAbp.ProcessManagement.UserGroups;
@@ -36,11 +37,11 @@ public class ProcessChangedEventHandler : ITransientDependency,
     {
         var userIds = await _userGroupManager.GetUserIdsAsync(eventData.Entity.GroupKey);
 
-        foreach (var userId in userIds)
-        {
-            await _notificationRepository.InsertAsync(
-                new Notification(_guidGenerator.Create(), eventData.Entity, userId), true);
-        }
+        var notifications = userIds
+            .Select(userId => new Notification(_guidGenerator.Create(), eventData.Entity, userId))
+            .ToList();
+
+        await _notificationRepository.InsertManyAsync(notifications, true);
     }
 
     [UnitOfWork]
@@ -49,23 +50,15 @@ public class ProcessChangedEventHandler : ITransientDependency,
         var now = _clock.Now;
         var userIds = await _userGroupManager.GetUserIdsAsync(eventData.Entity.GroupKey);
 
-        var oldNotifications = await _notificationRepository.GetListAsync(x => x.ProcessId == eventData.Entity.Id);
+        // Dismiss all existing notifications of this process in a single set-based update,
+        // without loading them into memory.
+        await _notificationRepository.DismissByProcessIdAsync(eventData.Entity.Id, now);
 
-        foreach (var oldNotification in oldNotifications)
-        {
-            if (oldNotification.DismissedTime.HasValue)
-            {
-                continue;
-            }
+        // Insert the notifications for the current group members in a single batch.
+        var notifications = userIds
+            .Select(userId => new Notification(_guidGenerator.Create(), eventData.Entity, userId))
+            .ToList();
 
-            oldNotification.SetDismissed(now);
-            await _notificationRepository.UpdateAsync(oldNotification);
-        }
-
-        foreach (var userId in userIds)
-        {
-            await _notificationRepository.InsertAsync(
-                new Notification(_guidGenerator.Create(), eventData.Entity, userId), true);
-        }
+        await _notificationRepository.InsertManyAsync(notifications, true);
     }
 }

--- a/src/EasyAbp.ProcessManagement.EntityFrameworkCore/EasyAbp/ProcessManagement/EntityFrameworkCore/Notifications/NotificationRepository.cs
+++ b/src/EasyAbp.ProcessManagement.EntityFrameworkCore/EasyAbp/ProcessManagement/EntityFrameworkCore/Notifications/NotificationRepository.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyAbp.ProcessManagement.Notifications;
+using Microsoft.EntityFrameworkCore;
 using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore;
 
@@ -16,5 +18,39 @@ public class NotificationRepository : EfCoreRepository<IProcessManagementDbConte
     public override async Task<IQueryable<Notification>> WithDetailsAsync()
     {
         return (await GetQueryableAsync()).IncludeDetails();
+    }
+
+    public virtual async Task DismissAllAsync(
+        Guid userId,
+        DateTime maxCreationTime,
+        DateTime dismissedTime,
+        CancellationToken cancellationToken = default)
+    {
+        var token = GetCancellationToken(cancellationToken);
+        var queryable = await GetQueryableAsync();
+
+        await queryable
+            .Where(x => x.UserId == userId &&
+                        x.CreationTime <= maxCreationTime &&
+                        x.DismissedTime == null)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(x => x.DismissedTime, dismissedTime),
+                token);
+    }
+
+    public virtual async Task DismissByProcessIdAsync(
+        Guid processId,
+        DateTime dismissedTime,
+        CancellationToken cancellationToken = default)
+    {
+        var token = GetCancellationToken(cancellationToken);
+        var queryable = await GetQueryableAsync();
+
+        await queryable
+            .Where(x => x.ProcessId == processId &&
+                        x.DismissedTime == null)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(x => x.DismissedTime, dismissedTime),
+                token);
     }
 }

--- a/test/EasyAbp.ProcessManagement.Application.Tests/Notifications/NotificationAppServiceTests.cs
+++ b/test/EasyAbp.ProcessManagement.Application.Tests/Notifications/NotificationAppServiceTests.cs
@@ -1,5 +1,12 @@
-using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using EasyAbp.ProcessManagement.Notifications.Dtos;
+using EasyAbp.ProcessManagement.Processes;
+using Shouldly;
+using Volo.Abp.Guids;
+using Volo.Abp.Users;
 using Xunit;
 
 namespace EasyAbp.ProcessManagement.Notifications;
@@ -7,22 +14,111 @@ namespace EasyAbp.ProcessManagement.Notifications;
 public class NotificationAppServiceTests : ProcessManagementApplicationTestBase
 {
     private readonly INotificationAppService _notificationAppService;
+    private readonly INotificationRepository _notificationRepository;
+    private readonly ICurrentUser _currentUser;
+    private readonly IGuidGenerator _guidGenerator;
 
     public NotificationAppServiceTests()
     {
         _notificationAppService = GetRequiredService<INotificationAppService>();
+        _notificationRepository = GetRequiredService<INotificationRepository>();
+        _currentUser = GetRequiredService<ICurrentUser>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
     }
 
-    /*
     [Fact]
-    public async Task Test1()
+    public async Task Dismiss_By_Ids_Should_Dismiss_Only_The_Specified_Notifications()
     {
         // Arrange
+        var notifications = await CreateNotificationsForCurrentUserAsync(3);
+        var toDismiss = notifications.Take(2).Select(x => x.Id).ToList();
 
         // Act
+        await _notificationAppService.DismissAsync(new DismissNotificationDto { NotificationIds = toDismiss });
 
         // Assert
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _notificationRepository.GetAsync(notifications[0].Id)).DismissedTime.ShouldNotBeNull();
+            (await _notificationRepository.GetAsync(notifications[1].Id)).DismissedTime.ShouldNotBeNull();
+            (await _notificationRepository.GetAsync(notifications[2].Id)).DismissedTime.ShouldBeNull();
+        });
     }
-    */
-}
 
+    [Fact]
+    public async Task Dismiss_By_MaxCreationTime_Should_Dismiss_All_Of_The_Users_Notifications()
+    {
+        // Arrange
+        var notifications = await CreateNotificationsForCurrentUserAsync(5);
+
+        // Act
+        await _notificationAppService.DismissAsync(
+            new DismissNotificationDto { MaxCreationTime = DateTime.Now.AddYears(10) });
+
+        // Assert
+        await WithUnitOfWorkAsync(async () =>
+        {
+            foreach (var notification in notifications)
+            {
+                (await _notificationRepository.GetAsync(notification.Id)).DismissedTime.ShouldNotBeNull();
+            }
+        });
+    }
+
+    [Fact]
+    public async Task ReadAsync_Should_Set_The_Read_Time()
+    {
+        // Arrange
+        var notifications = await CreateNotificationsForCurrentUserAsync(1);
+
+        // Act
+        await _notificationAppService.ReadAsync(notifications[0].Id);
+
+        // Assert
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _notificationRepository.GetAsync(notifications[0].Id)).ReadTime.ShouldNotBeNull();
+        });
+    }
+
+    [Fact]
+    public async Task GetListAsync_Should_Return_The_Current_Users_Notifications()
+    {
+        // Arrange
+        await CreateNotificationsForCurrentUserAsync(3);
+
+        // Act
+        var result = await _notificationAppService.GetListAsync(new NotificationGetListInput
+        {
+            UserId = _currentUser.GetId()
+        });
+
+        // Assert
+        result.TotalCount.ShouldBe(3);
+        result.Items.ShouldAllBe(x => x.UserId == _currentUser.GetId());
+    }
+
+    private async Task<List<Notification>> CreateNotificationsForCurrentUserAsync(int count)
+    {
+        var userId = _currentUser.GetId();
+
+        var process = new ProcessEto
+        {
+            Id = _guidGenerator.Create(),
+            ProcessName = "FakeExport",
+            CorrelationId = _guidGenerator.Create().ToString(),
+            GroupKey = "test",
+            StateName = "Ready",
+            StateFlag = ProcessStateFlag.Information,
+            StateUpdateTime = DateTime.Now
+        };
+
+        var notifications = Enumerable.Range(0, count)
+            .Select(_ => new Notification(_guidGenerator.Create(), process, userId))
+            .ToList();
+
+        await WithUnitOfWorkAsync(() => _notificationRepository.InsertManyAsync(notifications, autoSave: true));
+
+        return notifications;
+    }
+}

--- a/test/EasyAbp.ProcessManagement.Application.Tests/Notifications/NotificationCreatedEventHandlerTests.cs
+++ b/test/EasyAbp.ProcessManagement.Application.Tests/Notifications/NotificationCreatedEventHandlerTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EasyAbp.ProcessManagement.Notifications.Dtos;
+using EasyAbp.ProcessManagement.Processes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Shouldly;
+using Volo.Abp.Guids;
+using Volo.Abp.Modularity;
+using Xunit;
+
+namespace EasyAbp.ProcessManagement.Notifications;
+
+/// <summary>
+/// A counting fake replacing <see cref="INotificationPushService"/> so the test can assert
+/// how many times <see cref="NotificationCreatedEventHandler"/> actually executes.
+/// </summary>
+public class CountingNotificationPushService : INotificationPushService
+{
+    public List<Guid> PushedUserIds { get; } = [];
+
+    public Task PushNewNotificationAsync(Guid userId, NotificationDto notification)
+    {
+        PushedUserIds.Add(userId);
+        return Task.CompletedTask;
+    }
+}
+
+[DependsOn(typeof(ProcessManagementApplicationTestModule))]
+public class NotificationEventTestModule : AbpModule
+{
+    public override void ConfigureServices(ServiceConfigurationContext context)
+    {
+        context.Services.Replace(
+            ServiceDescriptor.Singleton<INotificationPushService, CountingNotificationPushService>());
+    }
+}
+
+public class NotificationCreatedEventHandlerTests : ProcessManagementTestBase<NotificationEventTestModule>
+{
+    private readonly INotificationRepository _notificationRepository;
+    private readonly IGuidGenerator _guidGenerator;
+    private readonly CountingNotificationPushService _pushService;
+
+    public NotificationCreatedEventHandlerTests()
+    {
+        _notificationRepository = GetRequiredService<INotificationRepository>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
+        _pushService = (CountingNotificationPushService)GetRequiredService<INotificationPushService>();
+    }
+
+    /// <summary>
+    /// Proves the batched insert introduced in <see cref="ProcessChangedEventHandler"/> does NOT
+    /// swallow the per-entity created event: a single <c>InsertManyAsync</c> of N notifications still
+    /// raises <c>EntityCreatedEventData&lt;Notification&gt;</c> N times, so the
+    /// <see cref="NotificationCreatedEventHandler"/> (and thus the SignalR push) runs once per notification.
+    /// </summary>
+    [Fact]
+    public async Task InsertManyAsync_Should_Trigger_NotificationCreatedEventHandler_Once_Per_Entity()
+    {
+        // Arrange
+        const int count = 50;
+        var notifications = BuildNotifications(count, out var expectedUserIds);
+
+        // Act - this is exactly the call ProcessChangedEventHandler now makes.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            await _notificationRepository.InsertManyAsync(notifications, autoSave: true);
+        });
+
+        // Assert - the push handler ran for every single notification.
+        _pushService.PushedUserIds.Count.ShouldBe(count);
+        _pushService.PushedUserIds.ShouldBe(expectedUserIds, ignoreOrder: true);
+    }
+
+    private List<Notification> BuildNotifications(int count, out List<Guid> userIds)
+    {
+        var process = new ProcessEto
+        {
+            Id = _guidGenerator.Create(),
+            ProcessName = "FakeExport",
+            CorrelationId = "test",
+            GroupKey = "test",
+            StateName = "Ready",
+            StateFlag = ProcessStateFlag.Information,
+            StateUpdateTime = DateTime.Now
+        };
+
+        var notifications = new List<Notification>();
+        userIds = [];
+
+        for (var i = 0; i < count; i++)
+        {
+            var userId = _guidGenerator.Create();
+            userIds.Add(userId);
+            notifications.Add(new Notification(_guidGenerator.Create(), process, userId));
+        }
+
+        return notifications;
+    }
+}

--- a/test/EasyAbp.ProcessManagement.Domain.Tests/Notifications/ProcessChangedEventHandlerTests.cs
+++ b/test/EasyAbp.ProcessManagement.Domain.Tests/Notifications/ProcessChangedEventHandlerTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EasyAbp.ProcessManagement.Processes;
+using EasyAbp.ProcessManagement.UserGroups;
+using Shouldly;
+using Volo.Abp.Domain.Entities.Events.Distributed;
+using Xunit;
+
+namespace EasyAbp.ProcessManagement.Notifications;
+
+public class ProcessChangedEventHandlerTests : ProcessManagementDomainTestBase
+{
+    private readonly ProcessChangedEventHandler _handler;
+    private readonly INotificationRepository _notificationRepository;
+
+    public ProcessChangedEventHandlerTests()
+    {
+        _handler = GetRequiredService<ProcessChangedEventHandler>();
+        _notificationRepository = GetRequiredService<INotificationRepository>();
+    }
+
+    [Fact]
+    public async Task Should_Create_A_Notification_For_Each_Group_User_On_Process_Created()
+    {
+        // Arrange
+        var process = NewProcess(TestGroupUserGroupContributor.GroupKey);
+
+        // Act
+        await _handler.HandleEventAsync(new EntityCreatedEto<ProcessEto>(process));
+
+        // Assert - one notification per group user, none dismissed.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var notifications = await _notificationRepository.GetListAsync(x => x.ProcessId == process.Id);
+
+            notifications.Count.ShouldBe(TestGroupUserGroupContributor.UserIds.Count);
+            notifications.Select(x => x.UserId)
+                .ShouldBe(TestGroupUserGroupContributor.UserIds, ignoreOrder: true);
+            notifications.ShouldAllBe(x => x.DismissedTime == null);
+        });
+    }
+
+    [Fact]
+    public async Task Should_Dismiss_Existing_Notifications_And_Create_New_On_Process_Updated()
+    {
+        // Arrange - a process that already has a notification per group user.
+        var process = NewProcess(TestGroupUserGroupContributor.GroupKey);
+        await _handler.HandleEventAsync(new EntityCreatedEto<ProcessEto>(process));
+
+        // Act - an update dismisses the existing notifications and creates fresh ones.
+        await _handler.HandleEventAsync(new EntityUpdatedEto<ProcessEto>(process));
+
+        // Assert
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var userCount = TestGroupUserGroupContributor.UserIds.Count;
+            var all = await _notificationRepository.GetListAsync(x => x.ProcessId == process.Id);
+
+            all.Count.ShouldBe(userCount * 2);
+            all.Count(x => x.DismissedTime != null).ShouldBe(userCount); // old ones dismissed
+            all.Count(x => x.DismissedTime == null).ShouldBe(userCount); // new ones active
+        });
+    }
+
+    [Fact]
+    public async Task Should_Not_Re_Dismiss_Already_Dismissed_Notifications_On_Update()
+    {
+        // Arrange - create, then update twice. The first update dismisses the original set;
+        // the second update must not touch those already-dismissed notifications again.
+        var process = NewProcess(TestGroupUserGroupContributor.GroupKey);
+        await _handler.HandleEventAsync(new EntityCreatedEto<ProcessEto>(process));
+        await _handler.HandleEventAsync(new EntityUpdatedEto<ProcessEto>(process));
+        await _handler.HandleEventAsync(new EntityUpdatedEto<ProcessEto>(process));
+
+        // Assert - 3 generations of notifications; only the latest generation stays active.
+        await WithUnitOfWorkAsync(async () =>
+        {
+            var userCount = TestGroupUserGroupContributor.UserIds.Count;
+            var all = await _notificationRepository.GetListAsync(x => x.ProcessId == process.Id);
+
+            all.Count.ShouldBe(userCount * 3);
+            all.Count(x => x.DismissedTime == null).ShouldBe(userCount);
+        });
+    }
+
+    private static ProcessEto NewProcess(string groupKey)
+    {
+        return new ProcessEto
+        {
+            Id = Guid.NewGuid(),
+            ProcessName = "FakeExport",
+            CorrelationId = Guid.NewGuid().ToString(),
+            GroupKey = groupKey,
+            StateName = "Ready",
+            StateFlag = ProcessStateFlag.Information,
+            StateUpdateTime = DateTime.Now
+        };
+    }
+}

--- a/test/EasyAbp.ProcessManagement.Domain.Tests/UserGroups/TestGroupUserGroupContributor.cs
+++ b/test/EasyAbp.ProcessManagement.Domain.Tests/UserGroups/TestGroupUserGroupContributor.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace EasyAbp.ProcessManagement.UserGroups;
+
+/// <summary>
+/// A test-only contributor that resolves a single group key into several fixed users, so tests can
+/// exercise the multi-user notification fan-out (the default <see cref="UserIdUserGroupContributor"/>
+/// only ever maps a key to one user). Inert for any key that does not use its prefix.
+/// </summary>
+public class TestGroupUserGroupContributor : UserGroupContributorBase
+{
+    public const string GroupKey = "T:multi";
+
+    public static readonly IReadOnlyList<Guid> UserIds =
+    [
+        Guid.Parse("11111111-1111-1111-1111-111111111111"),
+        Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        Guid.Parse("33333333-3333-3333-3333-333333333333")
+    ];
+
+    public override string GroupKeyPrefix => "T:";
+
+    protected override Task<List<Guid>> InternalGetUserIdsAsync(string originalKey)
+    {
+        return Task.FromResult(originalKey == "multi" ? UserIds.ToList() : []);
+    }
+
+    public override Task<List<string>> GetUserGroupKeysAsync(Guid userId)
+    {
+        return Task.FromResult<List<string>>(UserIds.Contains(userId) ? [GroupKey] : []);
+    }
+}

--- a/test/EasyAbp.ProcessManagement.Domain.Tests/UserGroups/UserGroupDomainTests.cs
+++ b/test/EasyAbp.ProcessManagement.Domain.Tests/UserGroups/UserGroupDomainTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
@@ -6,19 +7,47 @@ namespace EasyAbp.ProcessManagement.UserGroups;
 
 public class UserGroupDomainTests : ProcessManagementDomainTestBase
 {
+    private readonly IUserGroupManager _userGroupManager;
+
     public UserGroupDomainTests()
     {
+        _userGroupManager = GetRequiredService<IUserGroupManager>();
     }
 
-    /*
     [Fact]
-    public async Task Test1()
+    public async Task Default_Contributor_Should_Resolve_The_User_Id_From_Its_Group_Key()
     {
-        // Arrange
+        var userId = Guid.NewGuid();
 
-        // Assert
+        var userIds = await _userGroupManager.GetUserIdsAsync($"U:{userId}");
 
-        // Assert
+        userIds.ShouldContain(userId);
     }
-    */
+
+    [Fact]
+    public async Task Default_Contributor_Should_Resolve_The_Group_Key_For_A_User()
+    {
+        var userId = Guid.NewGuid();
+
+        var groupKeys = await _userGroupManager.GetUserGroupKeysAsync(userId);
+
+        groupKeys.ShouldContain($"U:{userId}");
+    }
+
+    [Fact]
+    public async Task Should_Aggregate_User_Ids_From_All_Contributors()
+    {
+        // The custom test contributor maps a single key to several users.
+        var userIds = await _userGroupManager.GetUserIdsAsync(TestGroupUserGroupContributor.GroupKey);
+
+        userIds.ShouldBe(TestGroupUserGroupContributor.UserIds, ignoreOrder: true);
+    }
+
+    [Fact]
+    public async Task Should_Return_Empty_For_An_Unknown_Group_Key_Prefix()
+    {
+        var userIds = await _userGroupManager.GetUserIdsAsync("unknown-prefix-key");
+
+        userIds.ShouldBeEmpty();
+    }
 }

--- a/test/EasyAbp.ProcessManagement.EntityFrameworkCore.Tests/EntityFrameworkCore/Notifications/NotificationRepositoryTests.cs
+++ b/test/EasyAbp.ProcessManagement.EntityFrameworkCore.Tests/EntityFrameworkCore/Notifications/NotificationRepositoryTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Threading.Tasks;
 using EasyAbp.ProcessManagement.Notifications;
-using Volo.Abp.Domain.Repositories;
+using EasyAbp.ProcessManagement.Processes;
+using Shouldly;
+using Volo.Abp.Guids;
 using Xunit;
 
 namespace EasyAbp.ProcessManagement.EntityFrameworkCore.Notifications;
@@ -9,24 +11,107 @@ namespace EasyAbp.ProcessManagement.EntityFrameworkCore.Notifications;
 public class NotificationRepositoryTests : ProcessManagementEntityFrameworkCoreTestBase
 {
     private readonly INotificationRepository _notificationRepository;
+    private readonly IGuidGenerator _guidGenerator;
 
     public NotificationRepositoryTests()
     {
         _notificationRepository = GetRequiredService<INotificationRepository>();
+        _guidGenerator = GetRequiredService<IGuidGenerator>();
     }
 
-    /*
+    /// <summary>
+    /// The set-based "dismiss all" must dismiss only the current user's not-yet-dismissed
+    /// notifications, leaving other users' notifications and already-dismissed ones untouched.
+    /// </summary>
     [Fact]
-    public async Task Test1()
+    public async Task DismissAllAsync_Should_Dismiss_Only_Not_Dismissed_Notifications_Of_The_User()
     {
+        // Arrange
+        var userA = _guidGenerator.Create();
+        var userB = _guidGenerator.Create();
+        var alreadyDismissedTime = new DateTime(2020, 1, 1);
+        var dismissTime = new DateTime(2026, 6, 30, 12, 0, 0);
+
+        var process = NewProcess();
+
+        var userANormal1 = new Notification(_guidGenerator.Create(), process, userA);
+        var userANormal2 = new Notification(_guidGenerator.Create(), process, userA);
+        var userAAlreadyDismissed = new Notification(_guidGenerator.Create(), process, userA);
+        userAAlreadyDismissed.SetDismissed(alreadyDismissedTime);
+        var userBNotification = new Notification(_guidGenerator.Create(), process, userB);
+
+        await WithUnitOfWorkAsync(() => _notificationRepository.InsertManyAsync(
+            [userANormal1, userANormal2, userAAlreadyDismissed, userBNotification], autoSave: true));
+
+        // Act
+        await WithUnitOfWorkAsync(() =>
+            _notificationRepository.DismissAllAsync(userA, DateTime.Now.AddYears(10), dismissTime));
+
+        // Assert
         await WithUnitOfWorkAsync(async () =>
         {
-            // Arrange
+            (await _notificationRepository.GetAsync(userANormal1.Id)).DismissedTime.ShouldBe(dismissTime);
+            (await _notificationRepository.GetAsync(userANormal2.Id)).DismissedTime.ShouldBe(dismissTime);
 
-            // Act
+            // Already-dismissed notification keeps its original time (not re-touched).
+            (await _notificationRepository.GetAsync(userAAlreadyDismissed.Id)).DismissedTime
+                .ShouldBe(alreadyDismissedTime);
 
-            //Assert
+            // Another user's notification stays untouched.
+            (await _notificationRepository.GetAsync(userBNotification.Id)).DismissedTime.ShouldBeNull();
         });
     }
-    */
+
+    /// <summary>
+    /// The set-based dismiss-by-process must dismiss only the targeted process's not-yet-dismissed
+    /// notifications, leaving other processes and already-dismissed ones untouched.
+    /// </summary>
+    [Fact]
+    public async Task DismissByProcessIdAsync_Should_Dismiss_Only_Not_Dismissed_Notifications_Of_The_Process()
+    {
+        // Arrange
+        var userId = _guidGenerator.Create();
+        var alreadyDismissedTime = new DateTime(2020, 1, 1);
+        var dismissTime = new DateTime(2026, 6, 30, 12, 0, 0);
+
+        var targetProcess = NewProcess();
+        var otherProcess = NewProcess();
+
+        var targetNormal = new Notification(_guidGenerator.Create(), targetProcess, userId);
+        var targetAlreadyDismissed = new Notification(_guidGenerator.Create(), targetProcess, userId);
+        targetAlreadyDismissed.SetDismissed(alreadyDismissedTime);
+        var otherProcessNotification = new Notification(_guidGenerator.Create(), otherProcess, userId);
+
+        await WithUnitOfWorkAsync(() => _notificationRepository.InsertManyAsync(
+            [targetNormal, targetAlreadyDismissed, otherProcessNotification], autoSave: true));
+
+        // Act
+        await WithUnitOfWorkAsync(() =>
+            _notificationRepository.DismissByProcessIdAsync(targetProcess.Id, dismissTime));
+
+        // Assert
+        await WithUnitOfWorkAsync(async () =>
+        {
+            (await _notificationRepository.GetAsync(targetNormal.Id)).DismissedTime.ShouldBe(dismissTime);
+
+            (await _notificationRepository.GetAsync(targetAlreadyDismissed.Id)).DismissedTime
+                .ShouldBe(alreadyDismissedTime);
+
+            (await _notificationRepository.GetAsync(otherProcessNotification.Id)).DismissedTime.ShouldBeNull();
+        });
+    }
+
+    private ProcessEto NewProcess()
+    {
+        return new ProcessEto
+        {
+            Id = _guidGenerator.Create(),
+            ProcessName = "FakeExport",
+            CorrelationId = "test",
+            GroupKey = "test",
+            StateName = "Ready",
+            StateFlag = ProcessStateFlag.Information,
+            StateUpdateTime = DateTime.Now
+        };
+    }
 }


### PR DESCRIPTION
## Problem

The notification **"dismiss all"** action gets very slow when a user has many notifications. `NotificationAppService.DismissAsync` loaded *every* matching notification into memory (including already-dismissed ones) and then issued **one `UPDATE` per row** in a loop — O(N) statements plus a large in-memory load.

`ProcessChangedEventHandler` had the same N+1 shape on process create/update: it dismissed old notifications one-by-one and inserted new ones with `autoSave: true` per user (one `SaveChanges` per row).

## Changes

- **Set-based repository methods** on `INotificationRepository`:
  - `DismissAllAsync(userId, maxCreationTime, dismissedTime)`
  - `DismissByProcessIdAsync(processId, dismissedTime)`

  Both implemented in the EF Core repository via `ExecuteUpdateAsync` → a single `UPDATE … WHERE … AND DismissedTime IS NULL`. No entities are materialized, and already-dismissed rows are skipped.
- **`NotificationAppService.DismissAsync`** uses `DismissAllAsync` for the `MaxCreationTime` ("dismiss all") path, and batches the `NotificationIds` path into one `GetList` + `UpdateMany` (was one `FindAsync` per id), preserving the existing `Process.Manage` permission check when notifications aren't owned by the current user.
- **`ProcessChangedEventHandler`** dismisses existing notifications set-based and inserts new ones with `InsertManyAsync`.
- Version bump `2.1.0` → `2.2.0`.

## Notes / behavior preserved

- No handler subscribes to notification *update* events, so the set-based updates bypassing change tracking / `EntityUpdated` events cause no regression.
- `InsertManyAsync` still raises `EntityCreatedEventData<Notification>` once per entity (default EF Core repository path, no bulk-operation provider registered), so `NotificationCreatedEventHandler` — and the SignalR push — still runs per notification. This is covered by a test.
- MongoDB was intentionally **not** changed: this module ships only an EF Core implementation for these repository methods.

## Tests

All green (Domain 15, Application 5, EF Core 2):

- **`NotificationRepositoryTests`** — `DismissAllAsync` / `DismissByProcessIdAsync` dismiss only the right not-yet-dismissed rows, leaving other users/processes and already-dismissed rows untouched.
- **`NotificationAppServiceTests`** — dismiss by ids, dismiss by max-creation-time, `ReadAsync`, `GetListAsync`.
- **`ProcessChangedEventHandlerTests`** — notification created per group user on process-created; dismissed + recreated on process-updated; no re-dismissal of already-dismissed on repeated updates.
- **`NotificationCreatedEventHandlerTests`** — `InsertManyAsync` of N notifications triggers the push handler exactly N times.
- **`UserGroupDomainTests`** — group-key ↔ user resolution and multi-contributor aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)